### PR TITLE
Add Palette Studio web and desktop application

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,24 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    node: true,
+    es2020: true
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true
+    }
+  },
+  plugins: ['react', '@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  rules: {
+    'react/react-in-jsx-scope': 'off'
+  }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+node_modules
+.DS_Store
+release
+dist
+dist-electron
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json
+*.sw?
+*.log
+.idea
+.vscode
+build/icon.icns
+build/icon.ico

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,130 @@
+# Palette Studio
+
+Palette Studio is a fully featured color palette designer that runs on the web and as a Windows desktop application powered by Electron. Explore expertly curated themes, craft custom palettes for both light and dark modes, preview UI components, and export the palette JSON for integration into design systems or codebases.
+
+## Features
+
+- **Extensive library** of 12 professional themes with coordinated light and dark variants.
+- **Custom palette builder** with per-role controls for both variants (background, surface, primary, link, text, muted, border).
+- **Live UI preview** showcasing navigation, cards, tables, CTAs, and feedback components rendered with the active palette.
+- **One-click JSON export** that works in the browser and Electron via the secure bridge layer.
+- **Electron packaging** for Windows using Electron Builder, including IPC-based file saving and production build pipeline.
+- **Modern stack** powered by Vite, React, TypeScript, Tailwind CSS utilities, ESLint, Prettier, and Vitest.
+
+## Getting started
+
+### Prerequisites
+
+- Node.js 18+
+- npm 9+
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+### Development workflows
+
+#### Run the web app
+
+```bash
+npm run dev
+```
+
+This starts Vite on <http://localhost:5173>. The UI updates instantly thanks to hot module replacement.
+
+#### Type checking & linting
+
+```bash
+npm run typecheck
+npm run lint
+```
+
+#### Run tests
+
+```bash
+npm run test
+```
+
+Vitest currently includes placeholder coverage you can extend with component tests.
+
+#### Build production web assets
+
+```bash
+npm run build
+```
+
+Output is written to `dist/`.
+
+### Electron development
+
+Compile the Electron process scripts and launch a development window connected to Vite:
+
+```bash
+npm run electron:compile
+npm run electron:dev
+```
+
+The first command transpiles `electron/*.ts` into `dist-electron/`. The second command runs Vite and opens Electron with live reload support. Use `Ctrl+Shift+I` to open the dev tools.
+
+### Package a Windows installer
+
+```bash
+npm run electron:build
+```
+
+This performs a production web build, compiles the Electron main & preload scripts, and then uses Electron Builder to generate an NSIS installer inside the `release/` directory.
+
+### Deploy the web build
+
+1. Run `npm run build`.
+2. Deploy the `dist/` folder to any static host (Netlify, Vercel, GitHub Pages, etc.).
+
+### App structure
+
+```
+├── electron/          # Electron main & preload process source
+├── public/            # Static assets (favicon)
+├── src/
+│   ├── components/    # Reusable UI components & previews
+│   ├── data/          # Palette definitions and typings
+│   ├── lib/           # Shared helpers (e.g., JSON export)
+│   └── styles/        # Tailwind entry point
+├── dist/              # Web production build (generated)
+└── dist-electron/     # Electron transpiled files (generated)
+```
+
+## JSON export format
+
+Click **Export JSON** to download a file shaped like the example below:
+
+```json
+{
+  "themeId": "modern",
+  "name": "Modern Theme",
+  "description": "Sleek interface with azure accents",
+  "currentVariant": "dark",
+  "variants": {
+    "dark": {
+      "background": { "name": "Jet Black", "hex": "#181A1B", "usage": "Main background" },
+      "surface": { "name": "Charcoal Gray", "hex": "#212325", "usage": "Surfaces" }
+    },
+    "light": {
+      "background": { "name": "Paper White", "hex": "#FFFFFF", "usage": "Main background" }
+    }
+  }
+}
+```
+
+Use this payload to power documentation sites, design tokens, or automated theme pipelines.
+
+## Accessibility tips
+
+- Ensure adequate contrast between text and backgrounds when editing palettes.
+- Keep semantic color naming consistent for long-term maintainability.
+- Validate theme combinations with tools such as Stark, axe DevTools, or the WCAG contrast calculator.
+
+## License
+
+[MIT](./LICENSE)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,0 +1,59 @@
+import { app, BrowserWindow, ipcMain, dialog } from 'electron';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+const isDev = !app.isPackaged;
+
+async function createWindow() {
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 840,
+    minWidth: 1080,
+    minHeight: 720,
+    autoHideMenuBar: true,
+    backgroundColor: '#09090b',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  if (isDev && process.env.ELECTRON_START_URL) {
+    await win.loadURL(process.env.ELECTRON_START_URL);
+    win.webContents.openDevTools({ mode: 'detach' });
+  } else {
+    const filePath = path.join(__dirname, '../dist/index.html');
+    await win.loadFile(filePath);
+  }
+}
+
+app.whenReady().then(() => {
+  ipcMain.handle('export-palette', async (_event, data: unknown, defaultFileName: string) => {
+    const result = await dialog.showSaveDialog({
+      defaultPath: defaultFileName,
+      filters: [{ name: 'JSON', extensions: ['json'] }],
+    });
+
+    if (result.canceled || !result.filePath) {
+      return;
+    }
+
+    const json = JSON.stringify(data, null, 2);
+    await fs.writeFile(result.filePath, json, 'utf8');
+  });
+
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,0 +1,6 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  exportPalette: (data: unknown, defaultFileName: string) =>
+    ipcRenderer.invoke('export-palette', data, defaultFileName),
+});

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "../dist-electron",
+    "rootDir": "./",
+    "module": "CommonJS",
+    "target": "ES2020",
+    "moduleResolution": "Node",
+    "isolatedModules": false,
+    "noEmit": false,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["../node_modules"]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Palette Studio</title>
+  </head>
+  <body class="bg-zinc-950">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "palette-studio",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Cross-platform color palette designer with Electron and Vite",
+  "main": "dist-electron/main.js",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "lint": "eslint \"src/**/*.{ts,tsx}\" electron --ext .ts,.tsx",
+    "format": "prettier --write .",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit",
+    "electron:dev": "concurrently \"npm:dev\" \"npm:electron:start\"",
+    "electron:start": "wait-on tcp:5173 && cross-env ELECTRON_START_URL=http://localhost:5173 electron ./dist-electron/main.js",
+    "electron:build": "npm run build && npm run electron:compile && electron-builder",
+    "electron:compile": "tsc -p electron/tsconfig.json"
+  },
+  "build": {
+    "appId": "com.palette.studio",
+    "productName": "Palette Studio",
+    "directories": {
+      "buildResources": "build",
+      "output": "release"
+    },
+    "files": [
+      "dist",
+      "dist-electron"
+    ],
+    "win": {
+      "target": "nsis"
+    }
+  },
+  "dependencies": {
+    "classnames": "^2.5.1",
+    "lucide-react": "^0.344.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.2.0",
+    "@types/node": "^20.11.24",
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.16",
+    "concurrently": "^8.2.2",
+    "cross-env": "^7.0.3",
+    "electron": "^28.2.3",
+    "electron-builder": "^24.6.4",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.33.2",
+    "jsdom": "^27.0.0",
+    "postcss": "^8.4.32",
+    "prettier": "^3.1.1",
+    "tailwindcss": "^3.4.1",
+    "ts-node": "^10.9.2",
+    "typescript": "5.3.3",
+    "vite": "^5.0.10",
+    "vitest": "^1.1.3",
+    "wait-on": "^7.1.0"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#6366f1" />
+      <stop offset="50%" stop-color="#22d3ee" />
+      <stop offset="100%" stop-color="#fb7185" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="32" fill="#111827" />
+  <path d="M28 92c16-12 24-32 36-32s20 20 36 32" stroke="url(#g)" stroke-width="12" stroke-linecap="round" fill="none" />
+  <circle cx="64" cy="48" r="18" fill="url(#g)" />
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,268 @@
+import { useMemo, useState } from 'react';
+import { Sidebar } from '@/components/Sidebar';
+import { PRESET_THEMES, PaletteTheme, RoleKey, ROLE_ORDER } from '@/data/themes';
+import { SwatchGrid } from '@/components/SwatchGrid';
+import { InterfacePreview } from '@/components/preview/InterfacePreview';
+import { Button } from '@/components/ui/button';
+import { Download, Moon, Sun } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { CustomPaletteForm } from '@/components/CustomPaletteForm';
+import { exportPalette } from '@/lib/export';
+
+const createBaseColor = (role: RoleKey, mode: 'light' | 'dark') => {
+  const defaults: Record<RoleKey, { hex: string; name: string; usage: string }> = {
+    background: {
+      hex: mode === 'dark' ? '#0f1115' : '#ffffff',
+      name: 'Background',
+      usage: 'Main application background',
+    },
+    surface: {
+      hex: mode === 'dark' ? '#181b21' : '#f3f4f6',
+      name: 'Surface',
+      usage: 'Cards and surfaces',
+    },
+    primary: {
+      hex: '#2563eb',
+      name: 'Primary',
+      usage: 'Primary buttons and highlights',
+    },
+    link: {
+      hex: '#38bdf8',
+      name: 'Link',
+      usage: 'Links and interactive states',
+    },
+    text: {
+      hex: mode === 'dark' ? '#f4f4f5' : '#0f172a',
+      name: 'Text',
+      usage: 'Body and heading text',
+    },
+    muted: {
+      hex: mode === 'dark' ? '#a1a1aa' : '#6b7280',
+      name: 'Muted',
+      usage: 'Secondary text and placeholders',
+    },
+    border: {
+      hex: mode === 'dark' ? '#27272a' : '#d1d5db',
+      name: 'Border',
+      usage: 'Dividers, outlines, inputs',
+    },
+  };
+
+  return {
+    role,
+    ...defaults[role],
+  };
+};
+
+const createCustomTheme = (): PaletteTheme => ({
+  id: 'custom',
+  title: 'Custom Theme',
+  subtitle: 'Design your own palette from scratch',
+  variants: {
+    dark: {
+      mode: 'dark',
+      colors: ROLE_ORDER.map((role) => createBaseColor(role, 'dark')),
+    },
+    light: {
+      mode: 'light',
+      colors: ROLE_ORDER.map((role) => createBaseColor(role, 'light')),
+    },
+  },
+});
+
+const themeToRoles = (theme: PaletteTheme) =>
+  (['dark', 'light'] as const).reduce(
+    (acc, mode) => ({
+      ...acc,
+      [mode]: theme.variants[mode].colors.reduce(
+        (inner, color) => ({
+          ...inner,
+          [color.role]: {
+            name: color.name,
+            hex: color.hex,
+            usage: color.usage,
+          },
+        }),
+        {} as Record<RoleKey, { name: string; hex: string; usage: string }>,
+      ),
+    }),
+    {} as Record<'dark' | 'light', Record<RoleKey, { name: string; hex: string; usage: string }>>,
+  );
+
+export default function App() {
+  const [library, setLibrary] = useState<PaletteTheme[]>(PRESET_THEMES);
+  const [customTheme, setCustomTheme] = useState<PaletteTheme>(() => createCustomTheme());
+  const [activeVariant, setActiveVariant] = useState<'light' | 'dark'>('dark');
+  const [activeId, setActiveId] = useState<string>('custom');
+
+  const themes = useMemo(() => [customTheme, ...library], [customTheme, library]);
+  const activeTheme = useMemo(
+    () => themes.find((theme) => theme.id === activeId) ?? themes[0],
+    [themes, activeId],
+  );
+
+  const exportData = useMemo(
+    () => ({
+      themeId: activeTheme.id,
+      name: activeTheme.title,
+      description: activeTheme.subtitle,
+      currentVariant: activeVariant,
+      variants: themeToRoles(activeTheme),
+    }),
+    [activeTheme, activeVariant],
+  );
+
+  const handleExport = () => {
+    const filename = `${activeTheme.id}-palette.json`;
+    return exportPalette(exportData, filename);
+  };
+
+  const handleUpdateCustomMeta = (field: 'title' | 'subtitle', value: string) => {
+    setCustomTheme((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleUpdateCustomColor = (
+    variant: 'light' | 'dark',
+    role: RoleKey,
+    field: 'name' | 'hex' | 'usage',
+    value: string,
+  ) => {
+    setCustomTheme((prev) => ({
+      ...prev,
+      variants: {
+        ...prev.variants,
+        [variant]: {
+          ...prev.variants[variant],
+          colors: prev.variants[variant].colors.map((color) => {
+            if (color.role !== role) {
+              return color;
+            }
+
+            if (field === 'hex') {
+              const sanitized = value.startsWith('#') ? value : `#${value}`;
+              return {
+                ...color,
+                hex: sanitized.toUpperCase(),
+              };
+            }
+
+            return {
+              ...color,
+              [field]: value,
+            };
+          }),
+        },
+      },
+    }));
+  };
+
+  const handleSaveCustom = () => {
+    const id = `custom-${Date.now()}`;
+    const snapshot: PaletteTheme = JSON.parse(JSON.stringify({ ...customTheme, id }));
+    const clonedTheme: PaletteTheme = {
+      ...snapshot,
+      id,
+    };
+    setLibrary((prev) => [clonedTheme, ...prev]);
+    setActiveId(id);
+  };
+
+  return (
+    <div className="flex h-screen w-full overflow-hidden bg-zinc-950 text-zinc-100">
+      <div className="grid h-full w-full grid-cols-1 md:grid-cols-[20rem_1fr]">
+        <Sidebar themes={themes} activeId={activeTheme.id} onSelect={setActiveId} />
+
+        <main className="flex h-full flex-col overflow-hidden">
+          <div className="custom-scroll flex-1 space-y-8 overflow-y-auto p-6">
+            <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div className="space-y-1">
+                <h1 className="text-3xl font-semibold tracking-tight">{activeTheme.title}</h1>
+                <p className="text-sm text-zinc-400">{activeTheme.subtitle}</p>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  variant="outline"
+                  onClick={() => setActiveVariant((mode) => (mode === 'dark' ? 'light' : 'dark'))}
+                  className="border-zinc-700 text-zinc-200"
+                >
+                  {activeVariant === 'dark' ? (
+                    <span className="inline-flex items-center gap-2">
+                      <Sun className="h-4 w-4" /> Light preview
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-2">
+                      <Moon className="h-4 w-4" /> Dark preview
+                    </span>
+                  )}
+                </Button>
+                <Button onClick={handleExport} className="gap-2">
+                  <Download className="h-4 w-4" /> Export JSON
+                </Button>
+              </div>
+            </header>
+
+            <CustomPaletteForm
+              theme={customTheme}
+              onUpdateMeta={handleUpdateCustomMeta}
+              onUpdateColor={handleUpdateCustomColor}
+              onSave={handleSaveCustom}
+            />
+
+            <section className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold">Palette swatches</h2>
+                <div className="flex gap-2">
+                  <Button
+                    variant={activeVariant === 'light' ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => setActiveVariant('light')}
+                  >
+                    <Sun className="mr-1 h-4 w-4" /> Light
+                  </Button>
+                  <Button
+                    variant={activeVariant === 'dark' ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => setActiveVariant('dark')}
+                  >
+                    <Moon className="mr-1 h-4 w-4" /> Dark
+                  </Button>
+                </div>
+              </div>
+              <SwatchGrid colors={activeTheme.variants[activeVariant].colors} />
+            </section>
+
+            <section className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold">UI component preview</h2>
+                <p className="text-xs uppercase tracking-wide text-zinc-500">
+                  Shows key elements styled with this palette
+                </p>
+              </div>
+              <InterfacePreview theme={activeTheme} variant={activeVariant} />
+            </section>
+
+            <section>
+              <Card className="border-zinc-800/80">
+                <CardHeader>
+                  <CardTitle className="text-base text-zinc-100">Export payload (read-only)</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <pre className="max-h-80 overflow-auto rounded-2xl border border-zinc-800/80 bg-black/50 p-4 text-xs text-zinc-200">
+{JSON.stringify(exportData, null, 2)}
+                  </pre>
+                </CardContent>
+              </Card>
+            </section>
+
+            <footer className="pb-6 text-center text-xs text-zinc-600">
+              Crafted with Palette Studio · Electron + Vite
+            </footer>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CustomPaletteForm.tsx
+++ b/src/components/CustomPaletteForm.tsx
@@ -1,0 +1,110 @@
+import { Fragment } from 'react';
+import { PaletteTheme, RoleKey, ROLE_ORDER } from '@/data/themes';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+interface CustomPaletteFormProps {
+  theme: PaletteTheme;
+  onUpdateMeta: (field: 'title' | 'subtitle', value: string) => void;
+  onUpdateColor: (
+    variant: 'light' | 'dark',
+    role: RoleKey,
+    field: 'name' | 'hex' | 'usage',
+    value: string,
+  ) => void;
+  onSave: () => void;
+}
+
+export function CustomPaletteForm({ theme, onUpdateMeta, onUpdateColor, onSave }: CustomPaletteFormProps) {
+  return (
+    <Card className="border-zinc-800/80">
+      <CardHeader>
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <CardTitle className="text-base text-zinc-100">Custom Palette Builder</CardTitle>
+            <p className="text-xs text-zinc-500">
+              Personalize both light and dark variants, then add them to your library.
+            </p>
+          </div>
+          <Button onClick={onSave} className="whitespace-nowrap">
+            Save Palette to Library
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-2 text-sm text-zinc-300">
+            <span className="text-xs uppercase tracking-wide text-zinc-400">Palette name</span>
+            <Input value={theme.title} onChange={(event) => onUpdateMeta('title', event.target.value)} />
+          </label>
+          <label className="space-y-2 text-sm text-zinc-300">
+            <span className="text-xs uppercase tracking-wide text-zinc-400">Description</span>
+            <Input value={theme.subtitle} onChange={(event) => onUpdateMeta('subtitle', event.target.value)} />
+          </label>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          {(['dark', 'light'] as const).map((variant) => (
+            <Card key={variant} className="border-zinc-800/80 bg-zinc-950/60">
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between text-sm text-zinc-100">
+                  <span className="capitalize">{variant} variant</span>
+                  <span className="text-xs font-normal text-zinc-500">{theme.variants[variant].mode}</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {ROLE_ORDER.map((role) => {
+                  const color = theme.variants[variant].colors.find((item) => item.role === role)!;
+                  return (
+                    <Fragment key={`${variant}-${role}`}>
+                      <div className="grid gap-3 rounded-2xl border border-zinc-800/80 bg-zinc-900/40 p-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                        <div className="space-y-2">
+                          <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-zinc-500">
+                            <span>{role}</span>
+                            <input
+                              type="color"
+                              value={color.hex.toLowerCase()}
+                              onChange={(event) => onUpdateColor(variant, role, 'hex', event.target.value)}
+                              className="h-8 w-10 cursor-pointer rounded border border-zinc-800 bg-transparent"
+                              aria-label={`${variant} ${role} color swatch`}
+                            />
+                          </div>
+                          <Input
+                            value={color.hex}
+                            onChange={(event) => onUpdateColor(variant, role, 'hex', event.target.value)}
+                            className="font-mono uppercase"
+                          />
+                        </div>
+                        <div className="space-y-3">
+                          <div className="grid gap-2 sm:grid-cols-2">
+                            <label className="text-xs uppercase tracking-wide text-zinc-500">
+                              Name
+                              <Input
+                                value={color.name}
+                                className="mt-1"
+                                onChange={(event) => onUpdateColor(variant, role, 'name', event.target.value)}
+                              />
+                            </label>
+                            <label className="text-xs uppercase tracking-wide text-zinc-500">
+                              Usage
+                              <Input
+                                value={color.usage}
+                                className="mt-1"
+                                onChange={(event) => onUpdateColor(variant, role, 'usage', event.target.value)}
+                              />
+                            </label>
+                          </div>
+                        </div>
+                      </div>
+                    </Fragment>
+                  );
+                })}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,68 @@
+import { useMemo, useState } from 'react';
+import { Search, Palette } from 'lucide-react';
+import { Input } from './ui/input';
+import { PaletteTheme } from '@/data/themes';
+
+interface SidebarProps {
+  themes: PaletteTheme[];
+  activeId: string;
+  onSelect: (id: string) => void;
+}
+
+export function Sidebar({ themes, activeId, onSelect }: SidebarProps) {
+  const [query, setQuery] = useState('');
+  const filtered = useMemo(() => {
+    if (!query) return themes;
+    const lower = query.toLowerCase();
+    return themes.filter((theme) =>
+      `${theme.title} ${theme.subtitle}`.toLowerCase().includes(lower),
+    );
+  }, [query, themes]);
+
+  return (
+    <aside className="flex h-full w-full flex-col gap-4 border-r border-zinc-800/70 bg-zinc-950/70 p-4">
+      <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-zinc-400">
+        <Palette className="h-4 w-4" /> Palettes
+      </div>
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-500" />
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search palettes"
+          className="pl-10"
+        />
+      </div>
+      <div className="custom-scroll grow space-y-1 overflow-y-auto pr-1">
+        {filtered.map((theme) => (
+          <button
+            key={theme.id}
+            type="button"
+            onClick={() => onSelect(theme.id)}
+            className={`w-full rounded-2xl border px-4 py-3 text-left transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 ${
+              theme.id === activeId
+                ? 'border-zinc-700 bg-zinc-900/70 text-zinc-100'
+                : 'border-transparent bg-zinc-900/30 text-zinc-400 hover:bg-zinc-900/60'
+            }`}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-sm font-semibold">{theme.title}</div>
+                <div className="text-xs text-zinc-500">{theme.subtitle}</div>
+              </div>
+              <div className="flex gap-1">
+                {theme.variants.dark.colors.slice(0, 3).map((color) => (
+                  <span
+                    key={`${theme.id}-${color.role}`}
+                    className="h-2 w-5 rounded-full"
+                    style={{ backgroundColor: color.hex }}
+                  />
+                ))}
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/SwatchGrid.tsx
+++ b/src/components/SwatchGrid.tsx
@@ -1,0 +1,23 @@
+import { PaletteColor } from '@/data/themes';
+import { Card, CardContent } from './ui/card';
+
+interface SwatchGridProps {
+  colors: PaletteColor[];
+}
+
+export function SwatchGrid({ colors }: SwatchGridProps) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+      {colors.map((color) => (
+        <Card key={color.role} className="overflow-hidden border-zinc-800/80">
+          <div className="h-32 w-full" style={{ backgroundColor: color.hex }} />
+          <CardContent className="space-y-1">
+            <div className="text-sm font-semibold text-zinc-100">{color.name}</div>
+            <div className="text-xs font-mono uppercase tracking-wide text-zinc-400">{color.hex}</div>
+            <div className="text-xs text-zinc-500">{color.usage}</div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/preview/InterfacePreview.tsx
+++ b/src/components/preview/InterfacePreview.tsx
@@ -1,0 +1,230 @@
+import { PaletteTheme, RoleKey } from '@/data/themes';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { CalendarDays, CheckCircle2, Mail, Star } from 'lucide-react';
+
+interface InterfacePreviewProps {
+  theme: PaletteTheme;
+  variant: 'light' | 'dark';
+}
+
+const fallbackByRole: Record<'light' | 'dark', Record<RoleKey, string>> = {
+  light: {
+    background: '#ffffff',
+    surface: '#f4f4f5',
+    primary: '#2563eb',
+    link: '#3b82f6',
+    text: '#0f172a',
+    muted: '#6b7280',
+    border: '#e5e7eb',
+  },
+  dark: {
+    background: '#09090b',
+    surface: '#18181b',
+    primary: '#38bdf8',
+    link: '#22d3ee',
+    text: '#f4f4f5',
+    muted: '#a1a1aa',
+    border: '#27272a',
+  },
+};
+
+export function InterfacePreview({ theme, variant }: InterfacePreviewProps) {
+  const palette = theme.variants[variant].colors;
+  const roleMap = palette.reduce((acc, color) => {
+    acc[color.role] = color.hex;
+    return acc;
+  }, {} as Record<RoleKey, string>);
+  const colors = { ...fallbackByRole[variant], ...roleMap };
+
+  return (
+    <div
+      className="space-y-6 rounded-3xl border border-zinc-800/80"
+      style={{ backgroundColor: colors.background, borderColor: colors.border }}
+    >
+      <header
+        className="flex flex-col gap-4 border-b px-6 py-4 md:flex-row md:items-center md:justify-between"
+        style={{ backgroundColor: colors.surface, borderColor: colors.border }}
+      >
+        <div className="flex items-center gap-2">
+          <div
+            className="h-10 w-10 rounded-full"
+            style={{ background: `linear-gradient(135deg, ${colors.primary}, ${colors.link})` }}
+          />
+          <div>
+            <p className="text-xs uppercase tracking-wider" style={{ color: colors.muted }}>
+              Palette Studio
+            </p>
+            <p className="text-lg font-semibold" style={{ color: colors.text }}>
+              Brand Kit Dashboard
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-3">
+          <Button variant="ghost" style={{ color: colors.link }}>
+            <Star className="h-4 w-4" /> Favorite
+          </Button>
+          <Button style={{ backgroundColor: colors.primary }}>Create Brief</Button>
+        </div>
+      </header>
+
+      <section className="grid gap-6 px-6 pb-6 lg:grid-cols-[2fr_1fr]">
+        <div className="space-y-6">
+          <Card style={{ backgroundColor: colors.surface, borderColor: colors.border }}>
+            <CardHeader>
+              <CardTitle style={{ color: colors.text }}>Marketing Snapshot</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-4 sm:grid-cols-3">
+                {[
+                  {
+                    title: 'Campaigns',
+                    value: '12 Active',
+                    icon: <CalendarDays className="h-4 w-4" />,
+                  },
+                  {
+                    title: 'Deliverables',
+                    value: '48 Tasks',
+                    icon: <CheckCircle2 className="h-4 w-4" />,
+                  },
+                  {
+                    title: 'Review Score',
+                    value: '4.8 / 5',
+                    icon: <Star className="h-4 w-4" />,
+                  },
+                ].map((stat) => (
+                  <div
+                    key={stat.title}
+                    className="rounded-2xl border p-4"
+                    style={{ borderColor: colors.border, backgroundColor: colors.background }}
+                  >
+                    <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide" style={{ color: colors.muted }}>
+                      {stat.icon}
+                      {stat.title}
+                    </div>
+                    <div className="mt-3 text-xl font-semibold" style={{ color: colors.text }}>
+                      {stat.value}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-6 space-y-2">
+                <p className="text-sm font-medium" style={{ color: colors.text }}>
+                  Team Notes
+                </p>
+                <p className="text-sm leading-relaxed" style={{ color: colors.muted }}>
+                  Keep typography, border, and background usage consistent with this palette. Use the
+                  primary color for dominant actions and the link color for navigation states.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card style={{ backgroundColor: colors.surface, borderColor: colors.border }}>
+            <CardHeader className="flex items-center justify-between">
+              <CardTitle style={{ color: colors.text }}>Component Inventory</CardTitle>
+              <Badge style={{ borderColor: colors.border, color: colors.link }}>Live</Badge>
+            </CardHeader>
+            <CardContent>
+              <table className="w-full table-fixed border-collapse text-left text-sm">
+                <thead>
+                  <tr style={{ color: colors.muted }}>
+                    <th className="pb-2">Component</th>
+                    <th className="pb-2">Usage</th>
+                    <th className="pb-2">Color</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[
+                    { name: 'Primary Button', usage: 'Actions', color: colors.primary },
+                    { name: 'Surface Card', usage: 'Backgrounds', color: colors.surface },
+                    { name: 'Text', usage: 'Typography', color: colors.text },
+                    { name: 'Border', usage: 'Dividers', color: colors.border },
+                  ].map((row) => (
+                    <tr key={row.name} className="border-t" style={{ borderColor: colors.border, color: colors.text }}>
+                      <td className="py-2">
+                        <div className="font-medium">{row.name}</div>
+                      </td>
+                      <td className="py-2 text-sm" style={{ color: colors.muted }}>
+                        {row.usage}
+                      </td>
+                      <td className="py-2">
+                        <span className="inline-flex items-center gap-2">
+                          <span className="h-4 w-4 rounded-full border" style={{ backgroundColor: row.color, borderColor: colors.border }} />
+                          <span className="font-mono text-xs uppercase" style={{ color: colors.muted }}>
+                            {row.color}
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="space-y-6">
+          <Card style={{ backgroundColor: colors.surface, borderColor: colors.border }}>
+            <CardHeader>
+              <CardTitle style={{ color: colors.text }}>Quick Actions</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                <Button className="w-full" style={{ backgroundColor: colors.primary }}>
+                  Publish Update
+                </Button>
+                <Button className="w-full" variant="outline" style={{ borderColor: colors.border, color: colors.text }}>
+                  Share Palette
+                </Button>
+                <Button className="w-full" variant="ghost" style={{ color: colors.link }}>
+                  View Guidelines
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card style={{ backgroundColor: colors.surface, borderColor: colors.border }}>
+            <CardHeader>
+              <CardTitle style={{ color: colors.text }}>Feedback</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                {[
+                  {
+                    author: 'Abby Mills',
+                    role: 'Design Director',
+                    message: 'Love the balance between action and neutral colors. Works well for accessibility.',
+                  },
+                  {
+                    author: 'Jon Hsu',
+                    role: 'Product Manager',
+                    message: 'Table zebra stripes look great against the surface background, keep them consistent.',
+                  },
+                ].map((feedback) => (
+                  <div key={feedback.author} className="rounded-2xl border p-4" style={{ borderColor: colors.border }}>
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-sm font-semibold" style={{ color: colors.text }}>
+                          {feedback.author}
+                        </p>
+                        <p className="text-xs" style={{ color: colors.muted }}>
+                          {feedback.role}
+                        </p>
+                      </div>
+                      <Mail className="h-4 w-4" style={{ color: colors.link }} />
+                    </div>
+                    <p className="mt-3 text-sm" style={{ color: colors.muted }}>
+                      {feedback.message}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,14 @@
+import { HTMLAttributes } from 'react';
+import clsx from 'classnames';
+
+export function Badge({ className, ...props }: HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center gap-1 rounded-full border border-zinc-700/70 bg-zinc-800/70 px-3 py-1 text-xs font-medium uppercase tracking-wide text-zinc-300',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,35 @@
+import { ButtonHTMLAttributes, forwardRef } from 'react';
+import clsx from 'classnames';
+
+type ButtonVariant = 'default' | 'outline' | 'ghost';
+type ButtonSize = 'sm' | 'md' | 'lg';
+
+const baseStyles = 'inline-flex items-center justify-center gap-2 rounded-xl font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 disabled:opacity-60 disabled:pointer-events-none';
+const variantStyles: Record<ButtonVariant, string> = {
+  default: 'bg-sky-500 text-white hover:bg-sky-400 shadow-card',
+  outline: 'border border-zinc-700 text-zinc-100 hover:bg-zinc-800/60',
+  ghost: 'text-zinc-300 hover:bg-zinc-800/40',
+};
+
+const sizeStyles: Record<ButtonSize, string> = {
+  sm: 'h-9 px-3 text-sm',
+  md: 'h-11 px-5 text-sm',
+  lg: 'h-12 px-6 text-base',
+};
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', size = 'md', ...props }, ref) => (
+    <button
+      ref={ref}
+      className={clsx(baseStyles, variantStyles[variant], sizeStyles[size], className)}
+      {...props}
+    />
+  ),
+);
+
+Button.displayName = 'Button';

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,28 @@
+import { HTMLAttributes } from 'react';
+import clsx from 'classnames';
+
+export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={clsx(
+        'rounded-2xl border border-zinc-800 bg-zinc-900/60 backdrop-blur supports-[backdrop-filter]:bg-zinc-900/40 shadow-card',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function CardHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={clsx('px-5 py-4 border-b border-zinc-800/80', className)} {...props} />
+  );
+}
+
+export function CardTitle({ className, ...props }: HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={clsx('text-sm font-semibold text-zinc-100', className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={clsx('px-5 py-4 space-y-3 text-sm text-zinc-300', className)} {...props} />;
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,12 @@
+import { forwardRef, InputHTMLAttributes } from 'react';
+import clsx from 'classnames';
+
+const baseStyles = 'flex h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900/80 px-3 text-sm text-zinc-100 placeholder:text-zinc-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 disabled:opacity-50 disabled:pointer-events-none';
+
+export const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type = 'text', ...props }, ref) => {
+    return <input ref={ref} type={type} className={clsx(baseStyles, className)} {...props} />;
+  },
+);
+
+Input.displayName = 'Input';

--- a/src/data/themes.test.ts
+++ b/src/data/themes.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { PRESET_THEMES, ROLE_ORDER } from './themes';
+
+describe('PRESET_THEMES', () => {
+  it('includes light and dark variants with consistent role coverage', () => {
+    expect(PRESET_THEMES.length).toBeGreaterThan(0);
+    for (const theme of PRESET_THEMES) {
+      for (const mode of ['light', 'dark'] as const) {
+        const colors = theme.variants[mode].colors;
+        expect(colors).toHaveLength(ROLE_ORDER.length);
+        const roles = colors.map((color) => color.role);
+        expect(new Set(roles).size).toBe(ROLE_ORDER.length);
+      }
+    }
+  });
+});

--- a/src/data/themes.ts
+++ b/src/data/themes.ts
@@ -1,0 +1,386 @@
+export type RoleKey =
+  | 'background'
+  | 'surface'
+  | 'primary'
+  | 'link'
+  | 'text'
+  | 'muted'
+  | 'border';
+
+export interface PaletteColor {
+  role: RoleKey;
+  name: string;
+  hex: string;
+  usage: string;
+}
+
+export interface PaletteVariant {
+  mode: 'light' | 'dark';
+  colors: PaletteColor[];
+}
+
+export interface PaletteTheme {
+  id: string;
+  title: string;
+  subtitle: string;
+  variants: {
+    light: PaletteVariant;
+    dark: PaletteVariant;
+  };
+}
+
+export const ROLE_ORDER: RoleKey[] = [
+  'background',
+  'surface',
+  'primary',
+  'link',
+  'text',
+  'muted',
+  'border',
+];
+
+const createVariant = (mode: 'light' | 'dark', colors: Omit<PaletteColor, 'role'>[]): PaletteVariant => ({
+  mode,
+  colors: colors.map((c, index) => ({ ...c, role: ROLE_ORDER[index] })),
+});
+
+const theme = (
+  id: string,
+  title: string,
+  subtitle: string,
+  dark: Omit<PaletteColor, 'role'>[],
+  light: Omit<PaletteColor, 'role'>[],
+): PaletteTheme => ({
+  id,
+  title,
+  subtitle,
+  variants: {
+    dark: createVariant('dark', dark),
+    light: createVariant('light', light),
+  },
+});
+
+export const PRESET_THEMES: PaletteTheme[] = [
+  theme(
+    'modern',
+    'Modern Theme',
+    'Sleek interface with azure accents',
+    [
+      { name: 'Jet Black', hex: '#181A1B', usage: 'Main background' },
+      { name: 'Charcoal Gray', hex: '#212325', usage: 'Surfaces' },
+      { name: 'Azure Blue', hex: '#0099FF', usage: 'Primary actions' },
+      { name: 'Cyan Blue', hex: '#38B6FF', usage: 'Links and toggles' },
+      { name: 'Soft White', hex: '#F1F1F1', usage: 'Main text' },
+      { name: 'Light Gray', hex: '#B3BAC2', usage: 'Muted text' },
+      { name: 'Slate Gray', hex: '#2C2F32', usage: 'Borders' },
+    ],
+    [
+      { name: 'Paper White', hex: '#FFFFFF', usage: 'Main background' },
+      { name: 'Card Gray', hex: '#F4F6F8', usage: 'Surfaces' },
+      { name: 'Action Blue', hex: '#2563EB', usage: 'Primary actions' },
+      { name: 'Link Blue', hex: '#3B82F6', usage: 'Links' },
+      { name: 'Text Dark', hex: '#0F172A', usage: 'Primary text' },
+      { name: 'Muted Text', hex: '#6B7280', usage: 'Secondary text' },
+      { name: 'Border Gray', hex: '#E5E7EB', usage: 'Borders' },
+    ],
+  ),
+  theme(
+    'blue-professional',
+    'Blue Professional',
+    'Business palette with navy base',
+    [
+      { name: 'Navy', hex: '#0B1220', usage: 'Main background' },
+      { name: 'Panel Blue', hex: '#101A2C', usage: 'Surfaces' },
+      { name: 'Primary Blue', hex: '#1D4ED8', usage: 'Primary actions' },
+      { name: 'Sky', hex: '#38BDF8', usage: 'Links and highlights' },
+      { name: 'Off White', hex: '#F8FAFC', usage: 'Headings' },
+      { name: 'Muted', hex: '#94A3B8', usage: 'Muted text' },
+      { name: 'Divider', hex: '#1F2937', usage: 'Borders' },
+    ],
+    [
+      { name: 'Porcelain', hex: '#FAFBFF', usage: 'Main background' },
+      { name: 'Sheet', hex: '#EEF2FF', usage: 'Surfaces' },
+      { name: 'Royal Blue', hex: '#1D4ED8', usage: 'Primary actions' },
+      { name: 'Sky', hex: '#38BDF8', usage: 'Links' },
+      { name: 'Charcoal', hex: '#0B1220', usage: 'Headings' },
+      { name: 'Muted', hex: '#475569', usage: 'Muted text' },
+      { name: 'Divider', hex: '#CBD5E1', usage: 'Borders' },
+    ],
+  ),
+  theme(
+    'emerald-luxury',
+    'Luxury Emerald',
+    'Deep emerald with warm neutrals',
+    [
+      { name: 'Carbon', hex: '#121414', usage: 'Main background' },
+      { name: 'Obsidian', hex: '#1B1F1E', usage: 'Surfaces' },
+      { name: 'Emerald', hex: '#10B981', usage: 'Primary actions' },
+      { name: 'Mint', hex: '#34D399', usage: 'Links' },
+      { name: 'Ivory', hex: '#F5F5F4', usage: 'Text' },
+      { name: 'Greige', hex: '#A8A29E', usage: 'Muted text' },
+      { name: 'Basalt', hex: '#2A2E2C', usage: 'Borders' },
+    ],
+    [
+      { name: 'Ivory', hex: '#FFFFFB', usage: 'Main background' },
+      { name: 'Parchment', hex: '#F3F2ED', usage: 'Surfaces' },
+      { name: 'Emerald', hex: '#10B981', usage: 'Primary actions' },
+      { name: 'Mint', hex: '#34D399', usage: 'Links' },
+      { name: 'Ink', hex: '#111827', usage: 'Text' },
+      { name: 'Stone', hex: '#6B7280', usage: 'Muted text' },
+      { name: 'Divider', hex: '#E5E7EB', usage: 'Borders' },
+    ],
+  ),
+  theme(
+    'soft-sand-champagne',
+    'Soft Sand & Champagne',
+    'Warm neutrals with soft gold accents',
+    [
+      { name: 'Night Sand', hex: '#141414', usage: 'Main background' },
+      { name: 'Taupe', hex: '#2A2A2A', usage: 'Surfaces' },
+      { name: 'Champagne', hex: '#F4DAB3', usage: 'Primary actions' },
+      { name: 'Gold', hex: '#E6C07B', usage: 'Links' },
+      { name: 'Ivory', hex: '#F7F7F5', usage: 'Text' },
+      { name: 'Warm Gray', hex: '#B8B4AE', usage: 'Muted text' },
+      { name: 'Drift', hex: '#3A3A3A', usage: 'Borders' },
+    ],
+    [
+      { name: 'Sand', hex: '#FFFBF5', usage: 'Main background' },
+      { name: 'Shell', hex: '#F5EFE6', usage: 'Surfaces' },
+      { name: 'Champagne', hex: '#E7CBA9', usage: 'Primary actions' },
+      { name: 'Gold', hex: '#D6AE6A', usage: 'Links' },
+      { name: 'Ink', hex: '#1F2937', usage: 'Text' },
+      { name: 'Mushroom', hex: '#8B8680', usage: 'Muted text' },
+      { name: 'Border', hex: '#E6E2DC', usage: 'Borders' },
+    ],
+  ),
+  theme(
+    'aqua-fresh',
+    'Aqua Fresh Modern',
+    'Cool aqua with crisp whites',
+    [
+      { name: 'Deep Sea', hex: '#0E1A1E', usage: 'Main background' },
+      { name: 'Reef', hex: '#142329', usage: 'Surfaces' },
+      { name: 'Aqua', hex: '#04C8C8', usage: 'Primary actions' },
+      { name: 'Teal', hex: '#2DD4BF', usage: 'Links' },
+      { name: 'Foam', hex: '#E6FFFB', usage: 'Text' },
+      { name: 'Mist', hex: '#93C5C5', usage: 'Muted text' },
+      { name: 'Kelp', hex: '#1F3A3A', usage: 'Borders' },
+    ],
+    [
+      { name: 'Foam', hex: '#F8FFFF', usage: 'Main background' },
+      { name: 'Shore', hex: '#E8F8F8', usage: 'Surfaces' },
+      { name: 'Aqua', hex: '#06B6D4', usage: 'Primary actions' },
+      { name: 'Teal', hex: '#14B8A6', usage: 'Links' },
+      { name: 'Slate', hex: '#0F172A', usage: 'Text' },
+      { name: 'Sea Smoke', hex: '#64748B', usage: 'Muted text' },
+      { name: 'Border', hex: '#D1FAF5', usage: 'Borders' },
+    ],
+  ),
+  theme(
+    'burgundy-wine',
+    'Burgundy Wine',
+    'Rich reds with deep accents',
+    [
+      { name: 'Cellar', hex: '#16080B', usage: 'Main background' },
+      { name: 'Barrel', hex: '#241016', usage: 'Surfaces' },
+      { name: 'Burgundy', hex: '#7A1E2C', usage: 'Primary actions' },
+      { name: 'Rose', hex: '#E11D48', usage: 'Links' },
+      { name: 'Cream', hex: '#FEF2F2', usage: 'Text' },
+      { name: 'Blush', hex: '#F9A8D4', usage: 'Muted text' },
+      { name: 'Grape Skin', hex: '#3A0D16', usage: 'Borders' },
+    ],
+    [
+      { name: 'Linen', hex: '#FFF5F7', usage: 'Main background' },
+      { name: 'Porcelain', hex: '#FFE9EE', usage: 'Surfaces' },
+      { name: 'Burgundy', hex: '#881337', usage: 'Primary actions' },
+      { name: 'Rose', hex: '#DB2777', usage: 'Links' },
+      { name: 'Ink', hex: '#1F2937', usage: 'Text' },
+      { name: 'Ash', hex: '#64748B', usage: 'Muted text' },
+      { name: 'Border', hex: '#FAD1E8', usage: 'Borders' },
+    ],
+  ),
+  theme(
+    'coral-sunset',
+    'Coral Sunset',
+    'Warm coral and peach tones',
+    [
+      { name: 'Dusk', hex: '#1A1412', usage: 'Main background' },
+      { name: 'Clay', hex: '#2A1F1C', usage: 'Surfaces' },
+      { name: 'Coral', hex: '#FB7185', usage: 'Primary actions' },
+      { name: 'Peach', hex: '#FCA5A5', usage: 'Links' },
+      { name: 'Lace', hex: '#FFF1F2', usage: 'Text' },
+      { name: 'Blush', hex: '#FBCFE8', usage: 'Muted text' },
+      { name: 'Terracotta', hex: '#3B2A28', usage: 'Borders' },
+    ],
+    [
+      { name: 'Lace', hex: '#FFF7F7', usage: 'Main background' },
+      { name: 'Shell', hex: '#FFECEC', usage: 'Surfaces' },
+      { name: 'Coral', hex: '#F97316', usage: 'Primary actions' },
+      { name: 'Peach', hex: '#FDA4AF', usage: 'Links' },
+      { name: 'Ink', hex: '#111827', usage: 'Text' },
+      { name: 'Mauve', hex: '#6B7280', usage: 'Muted text' },
+      { name: 'Border', hex: '#FED7D7', usage: 'Borders' },
+    ],
+  ),
+  theme(
+    'deep-purple-royalty',
+    'Deep Purple Royalty',
+    'Royal purples with cool contrasts',
+    [
+      { name: 'Midnight', hex: '#0E0A1A', usage: 'Main background' },
+      { name: 'Plum', hex: '#1A1226', usage: 'Surfaces' },
+      { name: 'Royal', hex: '#6D28D9', usage: 'Primary actions' },
+      { name: 'Amethyst', hex: '#A78BFA', usage: 'Links' },
+      { name: 'Snow', hex: '#F5F3FF', usage: 'Text' },
+      { name: 'Lilac', hex: '#C4B5FD', usage: 'Muted text' },
+      { name: 'Grape', hex: '#2D1B49', usage: 'Borders' },
+    ],
+    [
+      { name: 'Snow', hex: '#FCFAFF', usage: 'Main background' },
+      { name: 'Lavender', hex: '#F3E8FF', usage: 'Surfaces' },
+      { name: 'Royal', hex: '#7C3AED', usage: 'Primary actions' },
+      { name: 'Amethyst', hex: '#A78BFA', usage: 'Links' },
+      { name: 'Ink', hex: '#111827', usage: 'Text' },
+      { name: 'Slate', hex: '#6B7280', usage: 'Muted text' },
+      { name: 'Border', hex: '#E9D5FF', usage: 'Borders' },
+    ],
+  ),
+  theme(
+    'mocha-warmth',
+    'Mocha Warmth',
+    'Cozy browns with cream contrasts',
+    [
+      { name: 'Espresso', hex: '#14100C', usage: 'Main background' },
+      { name: 'Mocha', hex: '#231A14', usage: 'Surfaces' },
+      { name: 'Caramel', hex: '#D97706', usage: 'Primary actions' },
+      { name: 'Amber', hex: '#F59E0B', usage: 'Links' },
+      { name: 'Cream', hex: '#FAF7F2', usage: 'Text' },
+      { name: 'Latte', hex: '#D6CCC2', usage: 'Muted text' },
+      { name: 'Bean', hex: '#3B2F2F', usage: 'Borders' },
+    ],
+    [
+      { name: 'Cream', hex: '#FFFCF7', usage: 'Main background' },
+      { name: 'Oat', hex: '#F4ECE3', usage: 'Surfaces' },
+      { name: 'Caramel', hex: '#D97706', usage: 'Primary actions' },
+      { name: 'Amber', hex: '#F59E0B', usage: 'Links' },
+      { name: 'Cocoa', hex: '#1F2937', usage: 'Text' },
+      { name: 'Latte', hex: '#7D6F67', usage: 'Muted text' },
+      { name: 'Border', hex: '#E9E1D9', usage: 'Borders' },
+    ],
+  ),
+  theme(
+    'ethereal-gradient',
+    'Ethereal Gradient',
+    'Soft gradient-inspired blues and violets',
+    [
+      { name: 'Cosmos', hex: '#0B1020', usage: 'Main background' },
+      { name: 'Nebula', hex: '#151A2E', usage: 'Surfaces' },
+      { name: 'Iris', hex: '#6366F1', usage: 'Primary actions' },
+      { name: 'Aqua Glow', hex: '#22D3EE', usage: 'Links' },
+      { name: 'Starlight', hex: '#E2E8F0', usage: 'Text' },
+      { name: 'Mist', hex: '#94A3B8', usage: 'Muted text' },
+      { name: 'Orbit', hex: '#27324A', usage: 'Borders' },
+    ],
+    [
+      { name: 'Starlight', hex: '#F5F7FF', usage: 'Main background' },
+      { name: 'Cloud', hex: '#EEF2FF', usage: 'Surfaces' },
+      { name: 'Iris', hex: '#6366F1', usage: 'Primary actions' },
+      { name: 'Aqua Glow', hex: '#06B6D4', usage: 'Links' },
+      { name: 'Ink', hex: '#0F172A', usage: 'Text' },
+      { name: 'Ash', hex: '#64748B', usage: 'Muted text' },
+      { name: 'Border', hex: '#E2E8F0', usage: 'Borders' },
+    ],
+  ),
+  theme(
+    'green-modern',
+    'Green Modern',
+    'Modern UI with vivid green accents',
+    [
+      { name: 'Graphite', hex: '#111315', usage: 'Main background' },
+      { name: 'Charcoal', hex: '#1B1F22', usage: 'Surfaces' },
+      { name: 'Lime', hex: '#22C55E', usage: 'Primary actions' },
+      { name: 'Mint', hex: '#34D399', usage: 'Links' },
+      { name: 'Snow', hex: '#F3F4F6', usage: 'Text' },
+      { name: 'Dust', hex: '#9CA3AF', usage: 'Muted text' },
+      { name: 'Steel', hex: '#2F3439', usage: 'Borders' },
+    ],
+    [
+      { name: 'White', hex: '#FFFFFF', usage: 'Main background' },
+      { name: 'Panel', hex: '#F5F7F9', usage: 'Surfaces' },
+      { name: 'Lime', hex: '#22C55E', usage: 'Primary actions' },
+      { name: 'Mint', hex: '#10B981', usage: 'Links' },
+      { name: 'Ink', hex: '#0F172A', usage: 'Text' },
+      { name: 'Muted', hex: '#6B7280', usage: 'Muted text' },
+      { name: 'Border', hex: '#E5E7EB', usage: 'Borders' },
+    ],
+  ),
+  theme(
+    'pink-trendy',
+    'Pink Trendy',
+    'Trendy pinks with soft neutrals',
+    [
+      { name: 'Char', hex: '#141216', usage: 'Main background' },
+      { name: 'Smoky', hex: '#1E1A21', usage: 'Surfaces' },
+      { name: 'Hot Pink', hex: '#EC4899', usage: 'Primary actions' },
+      { name: 'Candy', hex: '#F472B6', usage: 'Links' },
+      { name: 'Porcelain', hex: '#FDF2F8', usage: 'Text' },
+      { name: 'Rose Dust', hex: '#F5A6C9', usage: 'Muted text' },
+      { name: 'Border', hex: '#3A2A35', usage: 'Borders' },
+    ],
+    [
+      { name: 'Blush', hex: '#FFF7FB', usage: 'Main background' },
+      { name: 'Shell', hex: '#FCE7F3', usage: 'Surfaces' },
+      { name: 'Hot Pink', hex: '#DB2777', usage: 'Primary actions' },
+      { name: 'Candy', hex: '#F472B6', usage: 'Links' },
+      { name: 'Ink', hex: '#111827', usage: 'Text' },
+      { name: 'Muted', hex: '#6B7280', usage: 'Muted text' },
+      { name: 'Border', hex: '#FBCFE8', usage: 'Borders' },
+    ],
+  ),
+  theme(
+    'enterprise-neutral',
+    'Enterprise Neutral',
+    'Corporate friendly neutral palette',
+    [
+      { name: 'Pitch', hex: '#0F1113', usage: 'Main background' },
+      { name: 'Panel', hex: '#171A1E', usage: 'Surfaces' },
+      { name: 'Blue Accent', hex: '#3B82F6', usage: 'Primary actions' },
+      { name: 'Cyan', hex: '#22D3EE', usage: 'Links' },
+      { name: 'Silver', hex: '#E5E7EB', usage: 'Text' },
+      { name: 'Slate', hex: '#94A3B8', usage: 'Muted text' },
+      { name: 'Divider', hex: '#2B3138', usage: 'Borders' },
+    ],
+    [
+      { name: 'Paper', hex: '#FFFFFF', usage: 'Main background' },
+      { name: 'Sheet', hex: '#F3F4F6', usage: 'Surfaces' },
+      { name: 'Blue Accent', hex: '#2563EB', usage: 'Primary actions' },
+      { name: 'Cyan', hex: '#06B6D4', usage: 'Links' },
+      { name: 'Charcoal', hex: '#0F172A', usage: 'Text' },
+      { name: 'Muted', hex: '#6B7280', usage: 'Muted text' },
+      { name: 'Border', hex: '#E5E7EB', usage: 'Borders' },
+    ],
+  ),
+  theme(
+    'professional-slate',
+    'Professional Slate',
+    'Serious slate grays with blue highlights',
+    [
+      { name: 'Coal', hex: '#0E0F12', usage: 'Main background' },
+      { name: 'Slate', hex: '#171A20', usage: 'Surfaces' },
+      { name: 'Steel Blue', hex: '#3B82F6', usage: 'Primary actions' },
+      { name: 'Sky', hex: '#60A5FA', usage: 'Links' },
+      { name: 'Frost', hex: '#E5E7EB', usage: 'Text' },
+      { name: 'Ash', hex: '#9CA3AF', usage: 'Muted text' },
+      { name: 'Divider', hex: '#2A2F38', usage: 'Borders' },
+    ],
+    [
+      { name: 'Porcelain', hex: '#F8FAFC', usage: 'Main background' },
+      { name: 'Panel', hex: '#EEF2F7', usage: 'Surfaces' },
+      { name: 'Steel Blue', hex: '#2563EB', usage: 'Primary actions' },
+      { name: 'Sky', hex: '#60A5FA', usage: 'Links' },
+      { name: 'Charcoal', hex: '#0B1220', usage: 'Text' },
+      { name: 'Muted', hex: '#64748B', usage: 'Muted text' },
+      { name: 'Border', hex: '#D1D5DB', usage: 'Borders' },
+    ],
+  ),
+];

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,0 +1,17 @@
+export async function exportPalette(data: unknown, filename: string) {
+  if (window.electronAPI) {
+    await window.electronAPI.exportPalette(data, filename);
+    return;
+  }
+
+  const json = JSON.stringify(data, null, 2);
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/tailwind.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,0 +1,36 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+html,
+body {
+  min-height: 100%;
+  background-color: #09090b;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(113, 113, 122, 0.5);
+  border-radius: 999px;
+}
+
+.custom-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(113, 113, 122, 0.4) transparent;
+}
+
+.custom-scroll::-webkit-scrollbar {
+  width: 10px;
+}
+
+.custom-scroll::-webkit-scrollbar-thumb {
+  background: rgba(113, 113, 122, 0.35);
+  border-radius: 999px;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+interface Window {
+  electronAPI?: {
+    exportPalette: (data: unknown, defaultFileName: string) => Promise<void>;
+  };
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['"Inter"', 'system-ui', 'sans-serif']
+      },
+      boxShadow: {
+        card: '0 15px 30px -15px rgba(15, 23, 42, 0.35)'
+      }
+    }
+  },
+  plugins: []
+} satisfies Config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "types": ["vitest"]
+  },
+  "include": ["src", "vite.config.ts", "electron"]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM"],
+    "types": ["node"],
+    "jsx": "react-jsx",
+    "allowJs": false,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src')
+    }
+  },
+  build: {
+    outDir: 'dist',
+    sourcemap: true
+  }
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts',
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + TypeScript workspace with Tailwind styling, reusable UI primitives, and curated theme data powering the palette explorer and preview experience
- implement custom palette builder with JSON export that works in browser and Electron alongside an expanded interface preview and theme library
- wire up Electron main/preload scripts and document development, build, and packaging workflows for web and Windows targets

## Testing
- npm run build
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e590a3a090832392e4d2200252d0b9